### PR TITLE
Update repo ignore files to account for the move into web/

### DIFF
--- a/.bzrignore
+++ b/.bzrignore
@@ -1,3 +1,3 @@
 CVS
-./sites/default/settings.php
-./sites/default/files
+./web/sites/default/settings.php
+./web/sites/default/files

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 # Ignore paths that contain user-generated content.
-/sites/*/files
-/sites/*/private
-/files/*
-/cache
+/web/sites/*/files
+/web/sites/*/private
+/web/files/*
+/web/cache
 
 # ** Only works in OSs that support newer versions of fnmatch (Bash 4+)
-/sites/default/**/files
-/sites/default/**/private
+/web/sites/default/**/files
+/web/sites/default/**/private
 
 # Packages #
 ############


### PR DESCRIPTION
When the docroot was moved into /web, the .gitignore / .bzrignore files were not updated to compensate.