### PR TITLE
Apply Tag1 Quo drupal-6.38-p6.patch

### DIFF
--- a/web/CHANGELOG.txt
+++ b/web/CHANGELOG.txt
@@ -1,3 +1,18 @@
+Drupal 6.38-p6, 2018-04-17 - SA-CORE-2018-006
+
+The path module allows users with the 'administer url aliases' permission to
+create pretty URLs for content.
+
+In certain circumstances the user can enter a particular path that triggers an
+open redirect to a malicious url.
+
+The issue is mitigated by the fact that the user needs the administer url
+aliases permission to exploit.
+
+Upstream reference:
+https://www.drupal.org/sa-core-2018-006
+
+
 Drupal 6.38-p5, 2018-04-25 - SA-CORE-2018-004
 
 A remote code execution vulnerability may exist within multiple subsystems of

--- a/web/includes/common.inc
+++ b/web/includes/common.inc
@@ -1540,6 +1540,10 @@ function url($path = NULL, $options = array()) {
   }
   elseif (!empty($path) && !$options['alias']) {
     $path = drupal_get_path_alias($path, isset($options['language']) ? $options['language']->language : '');
+    // Strip leading slashes from internal paths to prevent them becoming external
+    // URLs without protocol. /example.com should not be turned into
+    // //example.com.
+    $path = ltrim($path, '/');
   }
 
   if (function_exists('custom_url_rewrite_outbound')) {

--- a/web/modules/system/system.module
+++ b/web/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.38-p5');
+define('VERSION', '6.38-p6');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
Drupal 6.38-p6, 2018-04-17 - SA-CORE-2018-006

The path module allows users with the 'administer url aliases' permission to
create pretty URLs for content.

In certain circumstances the user can enter a particular path that triggers an
open redirect to a malicious url.

The issue is mitigated by the fact that the user needs the administer url
aliases permission to exploit.

Upstream reference:
https://www.drupal.org/sa-core-2018-006
