### PR TITLE
Apply Tag1 Quo drupal-6.38-p8.patch

### DIFF
--- a/web/CHANGELOG.txt
+++ b/web/CHANGELOG.txt
@@ -1,3 +1,15 @@
+Drupal 6.38-p8, 2019-04-17 - SA-CORE-2019-006
+
+jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products,
+mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution.
+
+If an unsanitized source object contained an enumerable __proto__ property, it
+could extend the native Object.prototype.
+
+Upstream reference:
+https://www.drupal.org/sa-core-2019-006
+CVE-2019-11358
+
 Drupal 6.38-p7, 2019-01-16 - SA-CORE-2019-002
 
 A remote code execution vulnerability exists in PHP's built-in phar stream

--- a/web/includes/common.inc
+++ b/web/includes/common.inc
@@ -2243,6 +2243,7 @@ function drupal_add_js($data = NULL, $type = 'module', $scope = 'header', $defer
       $javascript['header'] = array(
         'core' => array(
           'misc/jquery.js' => array('cache' => TRUE, 'defer' => FALSE, 'preprocess' => TRUE),
+          'misc/jquery-extend-3.4.0.js' => array('cache' => TRUE, 'defer' => FALSE, 'preprocess' => TRUE),
           'misc/drupal.js' => array('cache' => TRUE, 'defer' => FALSE, 'preprocess' => TRUE),
         ),
         'module' => array(),

--- a/web/misc/jquery-extend-3.4.0.js
+++ b/web/misc/jquery-extend-3.4.0.js
@@ -1,0 +1,174 @@
+/**
+ * For jQuery versions less than 3.4.0, this replaces the jQuery.extend
+ * function with the one from jQuery 3.4.0, slightly modified (documented
+ * below) to be compatible with older jQuery versions and browsers.
+ *
+ * This provides the Object.prototype pollution vulnerability fix to Drupal
+ * installations running older jQuery versions, including the versions shipped
+ * with Drupal core and https://www.drupal.org/project/jquery_update.
+ *
+ * @see https://github.com/jquery/jquery/pull/4333
+ */
+
+(function (jQuery) {
+
+// Do not override jQuery.extend() if the jQuery version is already >=3.4.0.
+var versionParts = jQuery.fn.jquery.split('.');
+var majorVersion = parseInt(versionParts[0]);
+var minorVersion = parseInt(versionParts[1]);
+var patchVersion = parseInt(versionParts[2]);
+var isPreReleaseVersion = (patchVersion.toString() !== versionParts[2]);
+if (
+  (majorVersion > 3) ||
+  (majorVersion === 3 && minorVersion > 4) ||
+  (majorVersion === 3 && minorVersion === 4 && patchVersion > 0) ||
+  (majorVersion === 3 && minorVersion === 4 && patchVersion === 0 && !isPreReleaseVersion)
+) {
+  return;
+}
+
+/**
+ * This adds some funtions from jQuery 1.4.4 (the default version used in
+ * Drupal 7) for when they aren't present, like when using jQuery 1.2.6 (the
+ * default version used in Drupal 6).
+ */
+
+if (typeof jQuery.type === 'undefined') {
+  var toString = Object.prototype.toString,
+      class2type = {};
+
+  // Populate the class2type map
+  jQuery.each("Boolean Number String Function Array Date RegExp Object".split(" "), function(i, name) {
+    class2type[ "[object " + name + "]" ] = name.toLowerCase();
+  });
+
+  jQuery.type = function (obj) {
+    return obj == null ?
+      String( obj ) :
+      class2type[ toString.call(obj) ] || "object";
+  };
+}
+
+if (typeof jQuery.isArray === 'undefined') {
+  jQuery.isArray = function (obj) {
+    return jQuery.type(obj) === "array";
+  };
+}
+
+if (typeof jQuery.isWindow === 'undefined') {
+  jQuery.isWindow = function (obj) {
+    return obj && typeof obj === "object" && "setInterval" in obj;
+  };
+}
+
+if (typeof jQuery.isPlainObject === 'undefined') {
+  var hasOwn = Object.prototype.hasOwnProperty;
+
+  jQuery.isPlainObject = function (obj) {
+    // Must be an Object.
+    // Because of IE, we also have to check the presence of the constructor property.
+    // Make sure that DOM nodes and window objects don't pass through, as well
+    if ( !obj || jQuery.type(obj) !== "object" || obj.nodeType || jQuery.isWindow( obj ) ) {
+      return false;
+    }
+
+    // Not own constructor property must be Object
+    if ( obj.constructor &&
+      !hasOwn.call(obj, "constructor") &&
+      !hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
+      return false;
+    }
+
+    // Own properties are enumerated firstly, so to speed up,
+    // if last one is own, then all properties are own.
+
+    var key;
+    for ( key in obj ) {}
+
+    return key === undefined || hasOwn.call( obj, key );
+  };
+}
+
+/**
+ * This is almost verbatim copied from jQuery 3.4.0.
+ *
+ * Only two minor changes have been made:
+ * - The call to isFunction() is changed to jQuery.isFunction().
+ * - The two calls to Array.isArray() is changed to jQuery.isArray().
+ *
+ * The above two changes ensure compatibility with all older jQuery versions
+ * (1.2.6 - 3.3.1) and older browser versions (e.g., IE8).
+ */
+jQuery.extend = jQuery.fn.extend = function() {
+  var options, name, src, copy, copyIsArray, clone,
+    target = arguments[ 0 ] || {},
+    i = 1,
+    length = arguments.length,
+    deep = false;
+
+  // Handle a deep copy situation
+  if ( typeof target === "boolean" ) {
+    deep = target;
+
+    // Skip the boolean and the target
+    target = arguments[ i ] || {};
+    i++;
+  }
+
+  // Handle case when target is a string or something (possible in deep copy)
+  if ( typeof target !== "object" && !jQuery.isFunction( target ) ) {
+    target = {};
+  }
+
+  // Extend jQuery itself if only one argument is passed
+  if ( i === length ) {
+    target = this;
+    i--;
+  }
+
+  for ( ; i < length; i++ ) {
+
+    // Only deal with non-null/undefined values
+    if ( ( options = arguments[ i ] ) != null ) {
+
+      // Extend the base object
+      for ( name in options ) {
+        copy = options[ name ];
+
+        // Prevent Object.prototype pollution
+        // Prevent never-ending loop
+        if ( name === "__proto__" || target === copy ) {
+          continue;
+        }
+
+        // Recurse if we're merging plain objects or arrays
+        if ( deep && copy && ( jQuery.isPlainObject( copy ) ||
+          ( copyIsArray = jQuery.isArray( copy ) ) ) ) {
+          src = target[ name ];
+
+          // Ensure proper type for the source value
+          if ( copyIsArray && !jQuery.isArray( src ) ) {
+            clone = [];
+          } else if ( !copyIsArray && !jQuery.isPlainObject( src ) ) {
+            clone = {};
+          } else {
+            clone = src;
+          }
+          copyIsArray = false;
+
+          // Never move original objects, clone them
+          target[ name ] = jQuery.extend( deep, clone, copy );
+
+          // Don't bring in undefined values
+        } else if ( copy !== undefined ) {
+          target[ name ] = copy;
+        }
+      }
+    }
+  }
+
+  // Return the modified object
+  return target;
+};
+
+})(jQuery);

--- a/web/modules/system/system.module
+++ b/web/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.38-p7');
+define('VERSION', '6.38-p8');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
Drupal 6.38-p8, 2019-04-17 - SA-CORE-2019-006

jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles ```jQuery.extend(true, {}, ...)``` because of ```Object.prototype``` pollution.

If an unsanitized source object contained an enumerable ```__proto__``` property, it could extend the native Object.prototype.

Upstream reference:
https://www.drupal.org/sa-core-2019-006
CVE-2019-11358