### PR TITLE
Apply Tag1 Quo drupal-6.38-p13.patch.

### DIFF
--- a/web/CHANGELOG.txt
+++ b/web/CHANGELOG.txt
@@ -1,3 +1,11 @@
+Drupal 6.38-p13, 2020-11-18 - SA-CORE-2020-012
+
+Drupal core does not properly sanitize certain filenames on uploaded files, which can lead to files being interpreted as the incorrect extension and served as the wrong MIME type or executed as PHP for certain hosting configurations.
+
+Upstream reference:
+https://www.drupal.org/sa-core-2020-012
+
+
 Drupal 6.38-p12, 2020-09-16 - SA-CORE-2020-007
 
 The Drupal AJAX API does not disable JSONP by default, which can lead to cross-site scripting.

--- a/web/includes/file.inc
+++ b/web/includes/file.inc
@@ -479,8 +479,8 @@ function file_move(&$source, $dest = 0, $replace = FILE_EXISTS_RENAME) {
  * exploit.php_.pps.
  *
  * Specifically, this function adds an underscore to all extensions that are
- * between 2 and 5 characters in length, internal to the file name, and not
- * included in $extensions.
+ * between 2 and 5 characters in length, internal to the file name, and either
+ * included in the list of unsafe extensions, or not included in $extensions.
  *
  * Function behavior is also controlled by the Drupal variable
  * 'allow_insecure_uploads'. If 'allow_insecure_uploads' evaluates to TRUE, no
@@ -489,7 +489,8 @@ function file_move(&$source, $dest = 0, $replace = FILE_EXISTS_RENAME) {
  * @param $filename
  *   File name to modify.
  * @param $extensions
- *   A space-separated list of extensions that should not be altered.
+ *   A space-separated list of extensions that should not be altered. Note that
+ *   extensions that are unsafe will be altered regardless of this parameter.
  * @param $alerts
  *   If TRUE, drupal_set_message() will be called to display a message if the
  *   file name was changed.
@@ -506,6 +507,10 @@ function file_munge_filename($filename, $extensions, $alerts = TRUE) {
     $filename = str_replace(chr(0), '', $filename);
 
     $whitelist = array_unique(explode(' ', trim($extensions)));
+
+    // Remove unsafe extensions from the whitelist. The list is copied from
+    // file_save_upload().
+    $whitelist = array_diff($whitelist, explode('|', 'php|phar|pl|py|cgi|asp|js'));
 
     // Split the filename up by periods. The first part becomes the basename
     // the last part the final extension.

--- a/web/modules/system/system.module
+++ b/web/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.38-p9');
+define('VERSION', '6.38-p13');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
Drupal 6.38-p13, 2020-11-18 - SA-CORE-2020-012

Drupal core does not properly sanitize certain filenames on uploaded files, which can lead to files being interpreted as the incorrect extension and served as the wrong MIME type or executed as PHP for certain hosting configurations.

Upstream reference:
https://www.drupal.org/sa-core-2020-012