### PR TITLE
Apply Tag1 Quo drupal-6.38-p14.patch

### DIFF
--- a/web/CHANGELOG.txt
+++ b/web/CHANGELOG.txt
@@ -1,3 +1,11 @@
+Drupal 6.38-p14, 2021-04-21 - SA-CORE-2021-002
+
+Drupal core's sanitization API fails to properly filter cross-site scripting under certain circumstances.
+
+Upstream reference:
+https://www.drupal.org/sa-core-2021-002
+
+
 Drupal 6.38-p13, 2020-11-18 - SA-CORE-2020-012
 
 Drupal core does not properly sanitize certain filenames on uploaded files, which can lead to files being interpreted as the incorrect extension and served as the wrong MIME type or executed as PHP for certain hosting configurations.

--- a/web/modules/filter/filter.module
+++ b/web/modules/filter/filter.module
@@ -1116,7 +1116,13 @@ function _filter_xss_attributes($attr) {
         // Attribute name, href for instance
         if (preg_match('/^([-a-zA-Z]+)/', $attr, $match)) {
           $attrname = strtolower($match[1]);
-          $skip = ($attrname == 'style' || substr($attrname, 0, 2) == 'on');
+          $skip = (
+            $attrname == 'style' ||
+            substr($attrname, 0, 2) == 'on' ||
+            substr($attrname, 0, 1) == '-' ||
+            // Ignore long attributes to avoid unnecessary processing overhead.
+            strlen($attrname) > 96
+          );
           $working = $mode = 1;
           $attr = preg_replace('/^[-a-zA-Z]+/', '', $attr);
         }

--- a/web/modules/system/system.module
+++ b/web/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.38-p13');
+define('VERSION', '6.38-p14');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
Drupal 6.38-p14, 2021-04-21 - SA-CORE-2021-002

Drupal core's sanitization API fails to properly filter cross-site scripting under certain circumstances.

Upstream reference:
https://www.drupal.org/sa-core-2021-002